### PR TITLE
Background added to the header

### DIFF
--- a/src/styles/burger-btn.css
+++ b/src/styles/burger-btn.css
@@ -5,6 +5,7 @@
   padding-inline-start: 0;
   background: none;
   border: none;
+  cursor: pointer;
 }
 
 .burger-btn__line,

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -9,6 +9,8 @@
   inset-block-start: 0;
   position: sticky;
   z-index: 2;
+  -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
 }
 
 .header__logo {
@@ -22,4 +24,12 @@
   block-size: 100%;
   inline-size: auto;
   vertical-align: middle;
+}
+
+@supports not (
+  (backdrop-filter: blur(5px)) or (-webkit-backdrop-filter: blur(5px))
+) {
+  .header {
+    background: var(--white);
+  }
 }


### PR DESCRIPTION
## About image and styles

In order for the image to be displayed and the styles applied, you need to run the command `npm run dev` before `npm run start` to create the bundle.

## Summary of changes

- I added the backdrop-filter property to the header component and also an alternative background to Firefox with the @supports rule.
- I change the cursor to pointer in the burger button component

Resolves #4

Please, check them